### PR TITLE
Add Shopping results page front-end

### DIFF
--- a/src/main/webapp/shopping-results-style.css
+++ b/src/main/webapp/shopping-results-style.css
@@ -1,0 +1,30 @@
+.jumbotron {
+  background-color: #fff;
+  margin-bottom: 0;
+  padding-bottom: 3rem;
+  padding-top: 3rem;
+}
+
+@media (min-width: 768px) {
+  .jumbotron {
+    padding-bottom: 6rem;
+    padding-top: 6rem;
+  }
+}
+
+.jumbotron p:last-child {
+  margin-bottom: 0;
+}
+
+.jumbotron h1 {
+  font-weight: 300;
+}
+
+.jumbotron .container {
+  max-width: 40rem;
+}
+
+/* Product price */
+.HRLxBb {
+  font-weight: bold;
+}

--- a/src/main/webapp/shopping-results.html
+++ b/src/main/webapp/shopping-results.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Shopping with photos">
+  
+  <!-- Bootstrap CSS -->
+  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css"
+    integrity="sha384-JcKb8q3iqJ61gNV9KGb8thSsNjpSL0n8PARn9HuZOnIxN0hoP+VmmDGMN5t9UJ0Z" crossorigin="anonymous">
+
+  <!-- Google Fonts -->
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Patrick+Hand+SC&display=swap">
+
+  <!-- CSS -->
+  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="shopping-results-style.css">
+
+  <title>Shopping with Photos</title>
+</head>
+<body>
+  <header>
+    <!-- Navigation Bar -->
+    <nav class="navbar navbar-expand-md navbar-dark fixed-top bg-dark">
+      <a class="navbar-brand" href="#">Shopping with photos</a>
+      <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarCollapse"
+        aria-controls="navbarCollapse" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse" id="navbarCollapse">
+        <ul class="navbar-nav mr-auto">
+          <li class="nav-item active">
+            <a class="nav-link" href="#">Home<span class="sr-only">(current)</span></a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="#">Contact us</a>
+          </li>
+        </ul>
+      </div>
+    </nav>
+  </header>
+
+  <main role="main">
+
+    <section class="jumbotron text-center">
+      <div class="container">
+        <h1>Shoping Results</h1>
+        <p class="lead text-muted">Here are the shopping results.</p>
+        <p>
+          <a href="index.html" class="btn btn-primary my-2">Back to search</a>
+        </p>
+      </div>
+    </section>
+
+    <div class="album py-5 bg-light">
+      <div class="container">
+          <div class="row" id="shopping-results-wrapper">
+          </div>
+      </div>
+    </div>
+
+  </main>
+
+  <!-- Sticky Footer -->
+  <footer class="footer mt-auto py-3">
+    <div class="container">
+      <span class="text-muted">Developed during the Google Student Training in Engineering Program · STEP · 2020</span>
+      <p class="float-right"><a href="#">Back to top</a></p>
+    </div>
+  </footer>
+
+  <script src="https://code.jquery.com/jquery-3.5.1.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.1/dist/umd/popper.min.js"
+    integrity="sha384-9/reFTGAW83EW2RDu2S0VKaIzap3H66lZH81PoYlFhbGU+6BZp6G7niu735Sk7lN"
+    crossorigin="anonymous"></script>
+  <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"
+    integrity="sha384-B4gt1jrGC7Jh4AgTPSdUtOBvfO8shuf57BaghqFfPlYxofvL8/KUEfYiJOMMV+rV"
+    crossorigin="anonymous"></script>
+
+  <script src="products-info-extraction.js"></script>
+  <script src="shopping-results.js"></script>
+</body>
+</html>

--- a/src/main/webapp/shopping-results.js
+++ b/src/main/webapp/shopping-results.js
@@ -1,0 +1,94 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Builds the Shopping Results Page UI by integrating product results from 
+ * Google Shopping into the webpage. 
+ */
+async function buildShoppingResultsUI() {
+  // Make a GET request to '/photo-shopping-request' to scrape the Google Shopping 
+  // search query results. The request returns a JSON with data about each product
+  // from the Google Shopping results page.
+
+  // Build the URL to be fetched - add (hard-coded, for now) parameters to identify 
+  // the uploaded photo.
+  const fetchURL = 
+      `/photo-shopping-request?photo-category=product`;
+
+  const response = await fetch(fetchURL)
+      .catch((error) => {
+        console.warn(error);
+        return new Response(JSON.stringify({
+          code: error.response.status,
+          message: `Failed to fetch ${fetchURL}`,
+        }));
+      });
+
+  if (!response.ok) {
+    return Promise.reject(response);
+  }
+
+  const products = await response.json();
+
+  // Integrate the products into the webpage.
+  products.forEach(product => {
+    // Create an HTML node for the item container.
+    let $productContainer = $('<div>', {class: 'col-md-4'});
+
+    // Get the HTML content for the container.
+    const productElementHTML = getProductElementHTML(product.title,
+                                                     product.imageLink,
+                                                     product.priceAndSeller,
+                                                     product.link,
+                                                     product.shippingPrice);
+
+    console.log(product.link);
+    // Load the content using jQuery's append.
+    $productContainer.append(productElementHTML);
+
+    // Add the container to the results page, into the corresponding product wrapper.
+    $('#shopping-results-wrapper').append($productContainer);
+  });
+}
+
+/**
+ * Returns the HTML content for a product container, based on the arguments.
+ */
+function getProductElementHTML(productTitle,
+                               productImageLink,
+                               productPriceAndSeller,
+                               productLink,
+                               productShippingPrice) {
+  return `<div class="card mb-4 shadow-sm">
+            <div class="col-4">
+              <img src="${productImageLink}" class="mx-auto d-block">
+            </div>
+            <div class="card-body">
+              <p class="card-text">${productTitle}</p>
+              <p class="card-text">${productPriceAndSeller}</p>
+              <div class="d-flex justify-content-between align-items-center">
+                <div class="btn-group">
+                  <button type="button" 
+                          class="btn btn-sm btn-outline-secondary" 
+                          onclick="window.location.href='${productLink}'">
+                    View
+                  </button>
+                </div>
+                <small class="text-muted">${productShippingPrice}</small>
+              </div>
+            </div>
+          </div>`;
+}
+
+buildShoppingResultsUI();

--- a/src/main/webapp/shopping-results.js
+++ b/src/main/webapp/shopping-results.js
@@ -53,7 +53,6 @@ async function buildShoppingResultsUI() {
                                                      product.link,
                                                      product.shippingPrice);
 
-    console.log(product.link);
     // Load the content using jQuery's append.
     $productContainer.append(productElementHTML);
 


### PR DESCRIPTION
Add HTML, CSS and JS for building the shopping results page.

Make a GET request to '/photo-shopping-request' to scrape the Google Shopping search query results. The request returns a JSON with data about each product from the Google Shopping results page (Now, the extraction of the product information only takes place in the back-end). Integrate the product data into the page 