### PR TITLE
Update ImageTextDetector test

### DIFF
--- a/src/main/java/com/google/sps/ImageTextDectector.java
+++ b/src/main/java/com/google/sps/ImageTextDectector.java
@@ -51,8 +51,9 @@ public class ImageTextDectector {
     }
 
     // Remove the first element of this list because cloud vision API returns all the 
-    // text detetcted as the first element of the list followed by list of single 
-    // words and their properties.
+    // text detected as the first element of the list followed by list of single 
+    // words and their properties. Documentation & example: 
+    // https://cloud.google.com/vision/docs/ocr#detect_text_in_a_remote_image
     shoppingListText.remove(0);
 
     if (shoppingListText.isEmpty()) {

--- a/src/main/java/com/google/sps/ImageTextDectector.java
+++ b/src/main/java/com/google/sps/ImageTextDectector.java
@@ -50,6 +50,15 @@ public class ImageTextDectector {
       throw new PhotoDetectionException("Shopping List doesn't contain any text");
     }
 
+    // Remove the first element of this list because cloud vision API returns all the 
+    // text detetcted as the first element of the list followed by list of single 
+    // words and their properties.
+    shoppingListText.remove(0);
+
+    if (shoppingListText.isEmpty()) {
+      throw new PhotoDetectionException("Shopping List doesn't contain any words");
+    }
+
     String queryItem = "";
     for (ShoppingListTextEntry singleWord : shoppingListText) {
       queryItem += singleWord.getText() + " ";

--- a/src/test/java/com/google/sps/ImageTextDectectorTest.java
+++ b/src/test/java/com/google/sps/ImageTextDectectorTest.java
@@ -45,6 +45,9 @@ public final class ImageTextDectectorTest {
    * object.
    */
   private void initImageTextDectector(List<ShoppingListTextEntry> shoppingListTextEntries) {
+    // Cloud vision API returns all the text detetcted as the first element of the list 
+    // followed by list of single words and their properties.
+    // So the first element is to be ignored while making shopping queries.
     shoppingListTextEntries.add(0, ShoppingListTextEntry.create("Will be ignored", 10));
     fakeTextDetectionAPIImpl.setReturnValue(shoppingListTextEntries);
     imageTextDectector = new ImageTextDectector(fakeTextDetectionAPIImpl);
@@ -72,9 +75,8 @@ public final class ImageTextDectectorTest {
   /** Negative test for no text */
   @Test
   public void noText() throws Exception {
-    List<ShoppingListTextEntry> shoppingListTextEntries= new ArrayList<>();
-
-    initImageTextDectector(shoppingListTextEntries);
+    fakeTextDetectionAPIImpl.setReturnValue(new ArrayList<>());
+    imageTextDectector = new ImageTextDectector(fakeTextDetectionAPIImpl);
 
     Exception exception =
         Assertions.assertThrows(

--- a/src/test/java/com/google/sps/ImageTextDectectorTest.java
+++ b/src/test/java/com/google/sps/ImageTextDectectorTest.java
@@ -45,6 +45,7 @@ public final class ImageTextDectectorTest {
    * object.
    */
   private void initImageTextDectector(List<ShoppingListTextEntry> shoppingListTextEntries) {
+    shoppingListTextEntries.add(0, ShoppingListTextEntry.create("Will be ignored", 10));
     fakeTextDetectionAPIImpl.setReturnValue(shoppingListTextEntries);
     imageTextDectector = new ImageTextDectector(fakeTextDetectionAPIImpl);
   }

--- a/src/test/java/com/google/sps/ImageTextDectectorTest.java
+++ b/src/test/java/com/google/sps/ImageTextDectectorTest.java
@@ -45,8 +45,9 @@ public final class ImageTextDectectorTest {
    * object.
    */
   private void initImageTextDectector(List<ShoppingListTextEntry> shoppingListTextEntries) {
-    // Cloud vision API returns all the text detetcted as the first element of the list 
-    // followed by list of single words and their properties.
+    // Cloud vision API returns all the text detected as the first element of the list 
+    // followed by list of single words and their properties. Documentation & example: 
+    // https://cloud.google.com/vision/docs/ocr#detect_text_in_a_remote_image
     // So the first element is to be ignored while making shopping queries.
     shoppingListTextEntries.add(0, ShoppingListTextEntry.create("Will be ignored", 10));
     fakeTextDetectionAPIImpl.setReturnValue(shoppingListTextEntries);


### PR DESCRIPTION
Adding a "will be ignored" text as the first list element of `shoppingListTextEntries` in test as the Cloud Vision API returns all the text detected as the first element of the list followed by list of single words and their properties. [Documentation & example](https://cloud.google.com/vision/docs/ocr#detect_text_in_a_remote_image)

